### PR TITLE
Fix Paragraph in AtomicReferenceCacheBackend doc

### DIFF
--- a/lib/thread_safe/atomic_reference_cache_backend.rb
+++ b/lib/thread_safe/atomic_reference_cache_backend.rb
@@ -44,7 +44,7 @@ module ThreadSafe
   # exactly the same +hash+ is a sure way to slow down performance of any hash
   # table.
   #
-  # == Design overview
+  # ## Design overview
   #
   # The primary design goal of this hash table is to maintain concurrent
   # readability (typically method +[]+, but also iteration and related methods)

--- a/lib/thread_safe/util/volatile.rb
+++ b/lib/thread_safe/util/volatile.rb
@@ -1,7 +1,9 @@
 module ThreadSafe
   module Util
     module Volatile
-      # Provides +volatile+ (in the JVM's sense) attribute accessors implemented atop of the +AtomicReference+s.
+      # Provides +volatile+ (in the JVM's sense) attribute accessors implemented
+      # atop of the +AtomicReference+s.
+      #
       # Usage:
       #   class Foo
       #     extend ThreadSafe::Util::Volatile


### PR DESCRIPTION
I've found a small error in AtomicReferenceCacheBackend docs.

This PR changes this:
![screenshot from 2015-03-09 00 13 22](https://cloud.githubusercontent.com/assets/4231743/6549411/3eb260e8-c5f1-11e4-8675-53d487dd0f85.png)

To this:
![screenshot from 2015-03-09 00 13 01](https://cloud.githubusercontent.com/assets/4231743/6549412/4052f5a2-c5f1-11e4-9f9b-ff9eda92ab48.png)
