### PR TITLE
Prep release 0.3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Gemfile.lock
+test/*.jar
 .rspec-local
 *.gem
 lib/1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,26 @@ jdk: # for JRuby only
 matrix:
   exclude:
     - rvm: 2.2.0
+      jdk: openjdk7
       jdk: oraclejdk8
     - rvm: 2.1.5
+      jdk: openjdk7
       jdk: oraclejdk8
     - rvm: 2.1.4
+      jdk: openjdk7
       jdk: oraclejdk8
     - rvm: 2.0.0
+      jdk: openjdk7
       jdk: oraclejdk8
     - rvm: 1.9.3
+      jdk: openjdk7
       jdk: oraclejdk8
     - rvm: ruby-head
+      jdk: openjdk7
       jdk: oraclejdk8
     - rvm: rbx-2
+      jdk: openjdk7
       jdk: oraclejdk8
-
-matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,5 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: 1.9.3
+
+script: "rake TESTOPTS='--seed=1'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,36 @@
 language: ruby
 rvm:
-  - jruby-18mode
-  - jruby-19mode
-  - rbx-2
-  - 1.8.7
-  - 1.9.3
+  - 2.2.0
+  - 2.1.5
+  - 2.1.4
   - 2.0.0
-  - 2.1.0
+  - 1.9.3
+  - ruby-head
+  - jruby-1.7.18
+  - jruby-head
+  - rbx-2
 jdk: # for JRuby only
   - openjdk7
   - oraclejdk8
 matrix:
   exclude:
-    - rvm: rbx-2
+    - rvm: 2.2.0
       jdk: oraclejdk8
-    - rvm: 1.8.7
+    - rvm: 2.1.5
       jdk: oraclejdk8
-    - rvm: 1.9.3
+    - rvm: 2.1.4
       jdk: oraclejdk8
     - rvm: 2.0.0
       jdk: oraclejdk8
-    - rvm: 2.1.0
+    - rvm: 1.9.3
       jdk: oraclejdk8
+    - rvm: ruby-head
+      jdk: oraclejdk8
+    - rvm: rbx-2
+      jdk: oraclejdk8
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
+    - rvm: 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :development, :test do
   gem 'minitest', '~> 5.5.1'
+  gem 'minitest-reporters', '~> 1.0.11'
   gem 'simplecov', '~> 0.9.2', :require => false
   gem 'coveralls', '~> 0.7.11', :require => false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,16 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in thread_safe.gemspec
 gemspec
+
+group :development, :test do
+  gem 'minitest', '~> 5.5.1'
+  gem 'simplecov', '~> 0.9.2', :require => false
+  gem 'coveralls', '~> 0.7.11', :require => false
+end
 
 group :documentation do
   gem 'countloc', '~> 0.4.0', :platforms => :mri, :require => false
-  gem 'rubycritic', '~> 1.0.2', :platforms => :mri, require: false
-  gem 'yard', '~> 0.8.7.4', :require => false
-  gem 'inch', '~> 0.4.6', :platforms => :mri, :require => false
-  gem 'redcarpet', '~> 3.1.2', platforms: :mri # understands github markdown
+  gem 'yard', '~> 0.8.7.6', :require => false
+  gem 'inch', '~> 0.5.10', :platforms => :mri, :require => false
+  gem 'redcarpet', '~> 3.2.2', platforms: :mri # understands github markdown
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Threadsafe
 
-[![Build Status](https://travis-ci.org/headius/thread_safe.png)](https://travis-ci.org/headius/thread_safe)
+[![Gem Version](https://badge.fury.io/rb/thread_safe.svg)](http://badge.fury.io/rb/thread_safe) [![Build Status](https://travis-ci.org/ruby-concurrency/thread_safe.svg?branch=master)](https://travis-ci.org/ruby-concurrency/thread_safe) [![Coverage Status](https://img.shields.io/coveralls/ruby-concurrency/thread_safe/master.svg)](https://coveralls.io/r/ruby-concurrency/thread_safe) [![Code Climate](https://codeclimate.com/github/ruby-concurrency/thread_safe.svg)](https://codeclimate.com/github/ruby-concurrency/thread_safe) [![Dependency Status](https://gemnasium.com/ruby-concurrency/thread_safe.svg)](https://gemnasium.com/ruby-concurrency/thread_safe) [![License](https://img.shields.io/badge/license-apache-green.svg)](http://opensource.org/licenses/MIT) [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/ruby-concurrency/concurrent-ruby)
 
 A collection of thread-safe versions of common core Ruby classes.
 

--- a/test/test_array.rb
+++ b/test/test_array.rb
@@ -4,7 +4,7 @@ require File.join(File.dirname(__FILE__), "test_helper")
 class TestArray < Minitest::Test
   def test_concurrency
     ary = ThreadSafe::Array.new
-    (1..100).map do |i|
+    (1..THREADS).map do |i|
       Thread.new do
         1000.times do
           ary << i

--- a/test/test_cache.rb
+++ b/test/test_cache.rb
@@ -11,7 +11,7 @@ class TestCache < Minitest::Test
 
   def test_concurrency
     cache = @cache
-    (1..100).map do |i|
+    (1..THREADS).map do |i|
       Thread.new do
         1000.times do |j|
           key = i*1000+j

--- a/test/test_hash.rb
+++ b/test/test_hash.rb
@@ -4,7 +4,7 @@ require File.join(File.dirname(__FILE__), "test_helper")
 class TestHash < Minitest::Test
   def test_concurrency
     hsh = ThreadSafe::Hash.new
-    (1..100).map do |i|
+    (1..THREADS).map do |i|
       Thread.new do
         1000.times do |j|
           hsh[i*1000+j] = i

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,9 @@ end
 
 require 'minitest/autorun'
 
+require 'minitest/reporters'
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new(color: true)
+
 require 'thread'
 require 'thread_safe'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,30 @@
-require 'thread'
-require 'rubygems'
-gem 'minitest', '>= 4'
+unless defined?(JRUBY_VERSION)
+  require 'simplecov'
+  require 'coveralls'
+
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+end
+
+SimpleCov.start do
+  project_name 'thread_safe'
+
+  add_filter '/examples/'
+  add_filter '/pkg/'
+  add_filter '/test/'
+  add_filter '/tasks/'
+  add_filter '/yard-template/'
+  add_filter '/yardoc/'
+
+  command_name 'Mintest'
+end
+
 require 'minitest/autorun'
 
-if Minitest.const_defined?('Test')
-  # We're on Minitest 5+. Nothing to do here.
-else
-  # Minitest 4 doesn't have Minitest::Test yet.
-  Minitest::Test = MiniTest::Unit::TestCase
-end
+require 'thread'
+require 'thread_safe'
 
 if defined?(JRUBY_VERSION) && ENV['TEST_NO_UNSAFE']
   # to be used like this: rake test TEST_NO_UNSAFE=true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,19 +6,19 @@ unless defined?(JRUBY_VERSION)
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
   ]
-end
 
-SimpleCov.start do
-  project_name 'thread_safe'
+  SimpleCov.start do
+    project_name 'thread_safe'
 
-  add_filter '/examples/'
-  add_filter '/pkg/'
-  add_filter '/test/'
-  add_filter '/tasks/'
-  add_filter '/yard-template/'
-  add_filter '/yardoc/'
+    add_filter '/examples/'
+    add_filter '/pkg/'
+    add_filter '/test/'
+    add_filter '/tasks/'
+    add_filter '/yard-template/'
+    add_filter '/yardoc/'
 
-  command_name 'Mintest'
+    command_name 'Mintest'
+  end
 end
 
 require 'minitest/autorun'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,8 @@ Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new(color: true)
 require 'thread'
 require 'thread_safe'
 
+THREADS = (RUBY_ENGINE == 'ruby' ? 100 : 10)
+
 if defined?(JRUBY_VERSION) && ENV['TEST_NO_UNSAFE']
   # to be used like this: rake test TEST_NO_UNSAFE=true
   load 'test/package.jar'

--- a/thread_safe.gemspec
+++ b/thread_safe.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.version       = ThreadSafe::VERSION
   gem.license       = "Apache-2.0"
 
-  gem.add_development_dependency 'atomic', ['>= 1.1.7', '< 2']
+  gem.add_development_dependency 'atomic', '= 1.1.16'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest', '>= 4'
 end


### PR DESCRIPTION
## Updated Project for 0.3.5 Release

* Added more and newer TravisCI build targets
* Integrated project with TravisCI, Coveralls, Code Climate, Gemnasium, and Gitter
  - Added badges to the README
* Setup SimpleCov for local code coverage reports
* Better test output (used when tracking down build problems)
* Reduced number of threads in non-MRI tests (was causing builds to crash)
* Updated `atomic` dependency to 1.1.16
* Set seed to 1 when running tests on TravisCI
* Updated gem dependencies
