### PR TITLE
gemspec: switch summary and description

### DIFF
--- a/thread_safe.gemspec
+++ b/thread_safe.gemspec
@@ -5,8 +5,8 @@ require 'thread_safe/version'
 Gem::Specification.new do |gem|
   gem.authors       = ["Charles Oliver Nutter", "thedarkone"]
   gem.email         = ["headius@headius.com", "thedarkone2@gmail.com"]
-  gem.description   = %q{Thread-safe collections and utilities for Ruby}
-  gem.summary       = %q{A collection of data structures and utilities to make thread-safe programming in Ruby easier}
+  gem.summary       = %q{Thread-safe collections and utilities for Ruby}
+  gem.description   = %q{A collection of data structures and utilities to make thread-safe programming in Ruby easier}
   gem.homepage      = "https://github.com/ruby-concurrency/thread_safe"
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
The `summary` variable in the gemspec is intended to be a small bit of text that presents the purpose of the gem in a short "at a glance" format.

The `description` variable is a longer characterization of the gem.

Prior to this commit, the two settings were reversed in the gemspec. Flip them here.

I'd originally posted this as https://github.com/headius/thread_safe/pull/47 , and then I found out that the canonical upstream repository has moved here.