### PR TITLE
tests: make minitest-reporters optional

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,8 +27,12 @@ end
 
 require 'minitest/autorun'
 
-require 'minitest/reporters'
-Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new(color: true)
+begin
+  require 'minitest/reporters'
+  Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new(color: true)
+rescue LoadError
+  warn "warning: minitest-reporters gem not found; skipping reporters output"
+end
 
 require 'thread'
 require 'thread_safe'


### PR DESCRIPTION
If we do not have minitest-reporters installed, we should be able to continue with the rest of the test suite.

This allows the tests to run outside of Bundler if minitest-reporters is not installed.