### PR TITLE
Modify README.md to explain code move to concurrent_ruby gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Threadsafe
+# Threadsafe (Inactive, code moved to concurrent-ruby gem and repo.)
 
 [![Gem Version](https://badge.fury.io/rb/thread_safe.svg)](http://badge.fury.io/rb/thread_safe) [![Build Status](https://travis-ci.org/ruby-concurrency/thread_safe.svg?branch=master)](https://travis-ci.org/ruby-concurrency/thread_safe) [![Coverage Status](https://img.shields.io/coveralls/ruby-concurrency/thread_safe/master.svg)](https://coveralls.io/r/ruby-concurrency/thread_safe) [![Code Climate](https://codeclimate.com/github/ruby-concurrency/thread_safe.svg)](https://codeclimate.com/github/ruby-concurrency/thread_safe) [![Dependency Status](https://gemnasium.com/ruby-concurrency/thread_safe.svg)](https://gemnasium.com/ruby-concurrency/thread_safe) [![License](https://img.shields.io/badge/license-apache-green.svg)](http://opensource.org/licenses/MIT) [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/ruby-concurrency/concurrent-ruby)
 
 A collection of thread-safe versions of common core Ruby classes.
+
+__This code base is now part of the concurrent-ruby gem
+at https://github.com/ruby-concurrency/concurrent-ruby.
+The code in this repository is no longer maintained.__
 
 ## Installation
 


### PR DESCRIPTION
I knew of the thread_safe gem several years ago.  Someone on StackOverflow asked what to use for a threadsafe hash.  I googled thread_safe to check to see if it was still available and found this repo, and recommended its use based on what I found.  There was no indication that I could find to tell me that it was inactive and that I should use concurrent_ruby instead.  This README change makes it obvious to anyone viewing it that they should use the concurrent_ruby gem instead of this code so that others won't make the same mistake.