### PR TITLE
Fix Ruby 2.4 Integer unification deprecation error and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,46 @@
+dist: trusty
+sudo: required
 language: ruby
 rvm:
-  - 2.2.0
-  - 2.1.5
-  - 2.1.4
+  - 2.4.0
+  - 2.3.3
+  - 2.2.6
+  - 2.1.9
   - 2.0.0
   - 1.9.3
   - ruby-head
-  - jruby-1.7.18
+  - jruby-9.1.5.0
+  - jruby-1.7.26
   - jruby-head
-  - rbx-2
-jdk: # for JRuby only
+  - rubinius-3
+  - rubinius-2
+jdk:
   - openjdk7
   - oraclejdk8
 matrix:
   exclude:
-    - rvm: 2.2.0
-      jdk: openjdk7
+    - rvm: 2.4.0
       jdk: oraclejdk8
-    - rvm: 2.1.5
-      jdk: openjdk7
+    - rvm: 2.3.3
       jdk: oraclejdk8
-    - rvm: 2.1.4
-      jdk: openjdk7
+    - rvm: 2.2.6
+      jdk: oraclejdk8
+    - rvm: 2.1.9
       jdk: oraclejdk8
     - rvm: 2.0.0
-      jdk: openjdk7
       jdk: oraclejdk8
     - rvm: 1.9.3
-      jdk: openjdk7
       jdk: oraclejdk8
     - rvm: ruby-head
-      jdk: openjdk7
       jdk: oraclejdk8
-    - rvm: rbx-2
-      jdk: openjdk7
+    - rvm: rubinius-3
+      jdk: oraclejdk8
+    - rvm: rubinius-2
       jdk: oraclejdk8
   allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
     - rvm: 1.9.3
-
-script: "rake test"
+    - rvm: ruby-head
+    - rvm: jruby-1.7.26
+    - rvm: jruby-head
+    - rvm: rubinius-2
+script: "bundle exec rake test"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ gemspec
 group :development, :test do
   gem 'rspec', '~> 3.2.0'
   gem 'simplecov', '~> 0.9.2', :require => false
+  if RUBY_VERSION < "2.0.0"
+    gem 'term-ansicolor', '~> 1.3.2', :require => false
+    gem 'tins', '~> 1.6.0', :require => false
+  end
   gem 'coveralls', '~> 0.7.11', :require => false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development, :test do
   gem 'rspec', '~> 3.2.0'
   gem 'simplecov', '~> 0.9.2', :require => false
-  if RUBY_VERSION < "2.0.0"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
     gem 'term-ansicolor', '~> 1.3.2', :require => false
     gem 'tins', '~> 1.6.0', :require => false
   end

--- a/lib/thread_safe/cache.rb
+++ b/lib/thread_safe/cache.rb
@@ -150,8 +150,8 @@ module ThreadSafe
     end
 
     def validate_options_hash!(options)
-      if (initial_capacity = options[:initial_capacity]) && (!initial_capacity.kind_of?(Fixnum) || initial_capacity < 0)
-        raise ArgumentError, ":initial_capacity must be a positive Fixnum"
+      if (initial_capacity = options[:initial_capacity]) && (!initial_capacity.kind_of?(0.class) || initial_capacity < 0)
+        raise ArgumentError, ":initial_capacity must be a positive #{0.class}"
       end
       if (load_factor = options[:load_factor]) && (!load_factor.kind_of?(Numeric) || load_factor <= 0 || load_factor > 1)
         raise ArgumentError, ":load_factor must be a number between 0 and 1"

--- a/thread_safe.gemspec
+++ b/thread_safe.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.add_development_dependency 'atomic', '= 1.1.16'
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rake', '< 12.0'
   gem.add_development_dependency 'rspec', '~> 3.2'
 end


### PR DESCRIPTION
• Solves the same issue as #27 in a slightly different way, using `0.class` as a backwards-compatible way of determining the correct Class to test in Ruby 2.4 vs. previous.
• Restrict dev dependency `rake` version so that Rakefile still parses.
• Restrict dev dependencies `term-ansicolor` and `tins` (dependencies of `coveralls`) to Ruby 1.9-compatible versions when necessary.
• Re-organize Travis CI config to get as many generations of Ruby builds passing as possible (only Rubinius 2 is broken, due to problems with the Rubinius binaries.)